### PR TITLE
Update return behavior for PR check

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -115,7 +115,7 @@ function main() {
     local changed=$(get_changed_dockerfiles "$commit_range")
     if [[ -z "$changed" ]]; then
         log "No VERSION files changed. Exiting"
-        [[ "$origin" == "pr" ]] && return 1 || return 0
+        return 0
     fi
 
     log "Changed directories are: $changed"
@@ -158,7 +158,9 @@ function main() {
         fi
     done
 
-    [[ -z "$DRY_RUN" ]] && [[ "$origin" == "build" ]] && update_previous_build_sha || return 1
+    if [[ -z "$DRY_RUN" ]] && [[ "$origin" == "build" ]]; then
+        update_previous_build_sha || return 1
+    fi
 
     return $rc
 }


### PR DESCRIPTION
Fix behavior on PR checks such that:

- If a PR check is not changing any versions then the output is a success code
- PR checks won't return an RC of 1 which was an error in the existing logic