### PR TITLE
APPSRE-6370: Update base image release tag to 0.8.9

### DIFF
--- a/qontract-reconcile-builder/Dockerfile
+++ b/qontract-reconcile-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-base:0.8.8 as base
+FROM quay.io/app-sre/qontract-reconcile-base:0.8.9 as base
 
 WORKDIR /work
 


### PR DESCRIPTION
Depends on: https://github.com/app-sre/container-images/pull/63

Related: [APPSRE-6370](https://issues.redhat.com/browse/APPSRE-6370)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>