### PR TITLE
Update base image versions to Red Hat's UBI relase 8.8

### DIFF
--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.4 AS downloader
+FROM registry.access.redhat.com/ubi8/ubi:8.8 AS downloader
 
 RUN dnf -y install unzip glibc-langpack-en
 
@@ -91,7 +91,7 @@ RUN curl -sfL https://github.com/prometheus/alertmanager/releases/download/v${AL
     | tar -zxf - -C /usr/local/bin --strip-components=1 alertmanager-${ALERTMANAGER_VERSION}.linux-amd64/amtool
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 ENV TF_PLUGIN_LOCAL_DIR=/usr/local/share/terraform/
 ENV TF_PLUGIN_CACHE_DIR=/.terraform.d/plugin-cache/


### PR DESCRIPTION
Update to the latest stable release of the `ubi` and `ubi-minimal` container images.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>