### PR TITLE
Fix crashing debug-container deployment

### DIFF
--- a/debug-container/openshift.yml
+++ b/debug-container/openshift.yml
@@ -30,6 +30,8 @@ objects:
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           name: debug-container
+          command: ["sleep"]
+          args: ["infinity"]
           resources:
             limits:
               cpu: ${{CPU_LIMIT}}


### PR DESCRIPTION
Since there's no command in the Dockerfile, the pod goes to Completed and the Deployment to CrashLoopBackOff