### PR TITLE
 latest jiralert and update images

### DIFF
--- a/jiralert/Dockerfile
+++ b/jiralert/Dockerfile
@@ -1,14 +1,14 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12 as builder
 ENV GOPATH=/go/
 ENV GO111MODULE=on
 USER root
 WORKDIR /go/src/github.com/prometheus-community/jiralert
 RUN git clone \
     https://github.com/prometheus-community/jiralert.git .
-RUN git checkout 7e2356af3ae8526235c9c4ebaf0420c9fd64b673
+RUN git checkout d43cbab62126d543e8e789f6374d9e745693cce2
 RUN make
 
-FROM registry.access.redhat.com/ubi8-minimal:8.5
+FROM registry.access.redhat.com/ubi8-minimal:8.9
 RUN microdnf update -y \
     && rm -rf /var/cache/yum \
     && microdnf install ca-certificates


### PR DESCRIPTION
Upgrade jiralert to the latest (unreleased) version to support `static_labels`. Additionally, use the latest ubi8 images.