### PR TITLE
9974: try making client FIPS compatible

### DIFF
--- a/debug-container-fedramp/Dockerfile
+++ b/debug-container-fedramp/Dockerfile
@@ -3,10 +3,11 @@
 # NOTE: postgres utils here are set to v14 by design
 FROM quay.io/fedora/fedora:39
 
-sudo fips-mode-setup --enable
+
 
 RUN dnf -y --refresh --security upgrade && \
         dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/F-39-x86_64/pgdg-fedora-repo-latest.noarch.rpm \
+        crypto-policies-scripts \
         python3-pip \
         python3-PyMySQL \
         python3-psycopg2 \
@@ -29,6 +30,8 @@ RUN dnf -y --refresh --security upgrade && \
         htop \
         alternatives \
     && dnf clean all
+
+RUN sudo fips-mode-setup --enable    
 
 RUN dnf -y install postgresql13 \
                    postgresql14 \

--- a/debug-container-fedramp/Dockerfile
+++ b/debug-container-fedramp/Dockerfile
@@ -3,6 +3,8 @@
 # NOTE: postgres utils here are set to v14 by design
 FROM quay.io/fedora/fedora:39
 
+sudo fips-mode-setup --enable
+
 RUN dnf -y --refresh --security upgrade && \
         dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/F-39-x86_64/pgdg-fedora-repo-latest.noarch.rpm \
         python3-pip \


### PR DESCRIPTION
[Context](https://sso.redhat.com/auth/realms/redhat-external/login-actions/authenticate?client_id=redhat-jira&tab_id=Jofz_uTpNd0)

Fix:

Run fips-mode-setup enable during build of container

