### PR TITLE
Vector FIPS Image

### DIFF
--- a/vector-fips/Dockerfile
+++ b/vector-fips/Dockerfile
@@ -8,7 +8,8 @@ RUN rpm -i https://yum.vector.dev/stable/vector-0/x86_64/vector-${VECTOR_VERSION
 
 COPY openssl-fips.cnf .
 
-ENV OPENSSL_CONF=/opt/vector/openssl-fips.cnf
-ENV OPENSSL_MODULES=/usr/lib64/ossl-modules/
+# in order to properly use FIPS libraries you need to pass the following environment variables
+# OPENSSL_CONF=/opt/vector/openssl-fips.cnf
+# OPENSSL_MODULES=/usr/lib64/ossl-modules/
 
 ENTRYPOINT ["/usr/bin/vector"]

--- a/vector-fips/Dockerfile
+++ b/vector-fips/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.4
+
+WORKDIR /opt/vector
+
+ENV VECTOR_VERSION="0.41.1"
+
+RUN rpm -i https://yum.vector.dev/stable/vector-0/x86_64/vector-${VECTOR_VERSION}-1.x86_64.rpm
+
+COPY openssl-fips.cnf .
+
+ENV OPENSSL_CONF=/opt/vector/openssl-fips.cnf
+ENV OPENSSL_MODULES=/usr/lib64/ossl-modules/
+
+ENTRYPOINT ["/usr/bin/vector"]

--- a/vector-fips/README.md
+++ b/vector-fips/README.md
@@ -1,0 +1,3 @@
+# vector-fips
+
+UBI-9 based image that bundles Vector in a FIPS compatible format.

--- a/vector-fips/openssl-fips.cnf
+++ b/vector-fips/openssl-fips.cnf
@@ -1,0 +1,19 @@
+config_diagnostics = 1
+openssl_config = openssl_init
+
+.include /etc/pki/tls/fips_local.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+fips = fips_sect
+base = base-sect
+
+
+[base_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes


### PR DESCRIPTION
[APPSRE-10876](https://issues.redhat.com/browse/APPSRE-10876)

Following [Vector's TLS documentation](https://vector.dev/docs/reference/configuration/tls/), I have created a new Docker image that allows Vector to be run using FIPS-compatible TLS algorithms when the user provides the following env variables to their container:

```
OPENSSL_CONF=/opt/vector/openssl-fips.cnf
OPENSSL_MODULES=/usr/lib64/ossl-modules/
```

Depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/119423