### PR TITLE
feature/appsre-11569-1: Upgrade FR debug-container to ubi9

### DIFF
--- a/debug-container-fedramp/Dockerfile
+++ b/debug-container-fedramp/Dockerfile
@@ -1,66 +1,66 @@
+
 # Build an AppSRE FedRamp-centric container for debugging issues (see git clone below)
-
-# NOTE: postgres utils here are set to v14 by design
-
-FROM quay.io/fedora/fedora:43@sha256:6949fc1c927bc4a9bf6ab81a995ac0f0f3bc69cdeeab2c90c42fb2b2906976ba
+FROM quay.io/app-sre/ubi9-ubi-minimal@sha256:94b434a29a894129301f6ff52dbddb19422fc800a109170c634b056da8cd704f
 COPY --from=ghcr.io/astral-sh/uv:0.6.14@sha256:3362a526af7eca2fcd8604e6a07e873fb6e4286d8837cb753503558ce1213664 /uv /bin/uv
 
 
-# since python tools are installed, install uv, see: 
+# install uv (see: https://docs.astral.sh/uv/guides/integration/docker/#using-uv-in-docker)
 ENV \
-    UV_PYTHON="/usr/bin/python3.12" \
-    # disable uv cache. it doesn't make sense in a container
+    UV_SYSTEM_PYTHON=1 \
     UV_NO_CACHE=true 
 
-# FedRamp specific version number
-ENV OCP_VERSION=4.14.45
-ENV OCP_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux-${OCP_VERSION}.tar.gz
-    
 
+RUN microdnf install -y dnf 
 RUN dnf -y --refresh --security upgrade && \
     dnf -y install \
         alternatives \
         bind-utils \
-        community-mysql \
-        curl \
         dnf-utils \
         dracut \
         git \
-        htop \
         iputils \
         mtr \
         net-tools \
         nmap \
         openssl \
-        perf \
         postgresql \
         procps-ng \
         python3-pip \
-        redis \
         rsync \
         skopeo \
         strace \
         tar \
-        tcpdump \
-        telnet \
-        tmux \
-        traceroute \
     && dnf clean all
+
+
+# Install FedRamp specific version number (see AppSRE-FT3)
+ENV OCP_VERSION=4.14.45
+ENV OCP_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux-${OCP_VERSION}.tar.gz
+RUN curl -LO ${OCP_URL} && \
+    tar -xvzf openshift-client-linux-${OCP_VERSION}.tar.gz && \
+    mv oc kubectl /usr/local/bin/ && \
+    chmod +x /usr/local/bin/oc /usr/local/bin/kubectl && \
+    rm -f 
+
+
+# anything normally installed via pip would go here (see: https://docs.astral.sh/uv/guides/integration/docker/#using-the-pip-interface)
+RUN uv pip install --system awscli redis psycopg PyMySQL
 
    
 RUN dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-9.2-x86_64 \
  && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-9.2-x86_64 \
  && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-9.2-x86_64 \
  && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-9.2-x86_64 \
- && dnf update -y \
- && dnf repolist \
- && dnf -y module disable postgresql
+ && dnf update -y 
+
+ 
 
 RUN dnf -y --nogpgcheck install postgresql13 \ 
                                 postgresql14 \
                                 postgresql15 \
                                 postgresql16 \
- && dnf clean all
+                             && dnf clean all \
+                             && rm -rf /var/cache/dnf
 
 RUN export PGSSLCIPHERS='TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:scram-sha-256'
 RUN export OPENSSL_FIPS=1
@@ -74,10 +74,6 @@ RUN alternatives --install /usr/bin/psql psql /usr/pgsql-13/bin/psql 130 && \
 
 RUN chmod -R 775 /var/lib/alternatives/ 
 RUN chmod -R 775 /etc/alternatives/ 
-
-
-RUN uv tool install awscli redis python3-PyMySQL python3-psycopg2
-
 
 ENV PS1="\[\e[31m\]\[\e[0m\]\ndebug-fedramp\[\e[0;32m\]\u\[\e[m\]@\[\e[0;33m\]\h\[\e[m\]:\[\e[0;34m\]\w\[\e[m\] \$ "
 

--- a/debug-container-fedramp/Dockerfile
+++ b/debug-container-fedramp/Dockerfile
@@ -11,6 +11,8 @@ ENV \
 
 
 RUN microdnf install -y dnf 
+
+
 RUN dnf -y --refresh --security upgrade && \
     dnf -y install \
         alternatives \
@@ -32,6 +34,8 @@ RUN dnf -y --refresh --security upgrade && \
         tar \
     && dnf clean all
 
+#requires dnf-utils to be present
+RUN dnf config-manager --set-enabled ubi-9-baseos-rpms ubi-9-codeready-builder-rpms ubi-9-appstream-rpms    
 
 # Install FedRamp specific version number (see AppSRE-FT3)
 ENV OCP_VERSION=4.14.45
@@ -41,6 +45,7 @@ RUN curl -LO ${OCP_URL} && \
     mv oc kubectl /usr/local/bin/ && \
     chmod +x /usr/local/bin/oc /usr/local/bin/kubectl && \
     rm -f 
+
 
 
 # anything normally installed via pip would go here (see: https://docs.astral.sh/uv/guides/integration/docker/#using-the-pip-interface)

--- a/debug-container-fedramp/Dockerfile
+++ b/debug-container-fedramp/Dockerfile
@@ -1,37 +1,66 @@
 # Build an AppSRE FedRamp-centric container for debugging issues (see git clone below)
 
 # NOTE: postgres utils here are set to v14 by design
-#FROM registry.access.redhat.com/ubi8/ubi:8.8
-FROM registry.access.redhat.com/ubi8/ubi:8.10
+
+FROM quay.io/fedora/fedora:43@sha256:6949fc1c927bc4a9bf6ab81a995ac0f0f3bc69cdeeab2c90c42fb2b2906976ba
+COPY --from=ghcr.io/astral-sh/uv:0.6.14@sha256:3362a526af7eca2fcd8604e6a07e873fb6e4286d8837cb753503558ce1213664 /uv /bin/uv
+
+
+# since python tools are installed, install uv, see: 
+ENV \
+    UV_PYTHON="/usr/bin/python3.12" \
+    # disable uv cache. it doesn't make sense in a container
+    UV_NO_CACHE=true 
+
+# FedRamp specific version number
+ENV OCP_VERSION=4.14.45
+ENV OCP_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux-${OCP_VERSION}.tar.gz
+    
 
 RUN dnf -y --refresh --security upgrade && \
-    dnf -y install dnf-utils \
+    dnf -y install \
+        alternatives \
+        bind-utils \
+        community-mysql \
+        curl \
+        dnf-utils \
         dracut \
-        python3-pip \
-        python3-PyMySQL \
-        python3-psycopg2 \
         git \
-        nmap \
-        bind-utils \ 
+        htop \
+        iputils \
+        mtr \
         net-tools \
+        nmap \
+        openssl \
+        perf \
+        postgresql \
+        procps-ng \
+        python3-pip \
+        redis \
         rsync \
         skopeo \
-        iputils \
-        alternatives 
-    
-RUN dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-8.8-x86_64 \
-    && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-8.8-x86_64 \
-    && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-8.8-x86_64 \
-    && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-8.8-x86_64 \
-    && dnf update -y \
-    && dnf repolist \
-    && dnf -y module disable postgresql
-    #&& dnf -y module enable postgresql:13 postgresql:14 postgresql:15 postgresql:16 \
+        strace \
+        tar \
+        tcpdump \
+        telnet \
+        tmux \
+        traceroute \
+    && dnf clean all
+
+   
+RUN dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-9.2-x86_64 \
+ && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-9.2-x86_64 \
+ && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-9.2-x86_64 \
+ && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-9.2-x86_64 \
+ && dnf update -y \
+ && dnf repolist \
+ && dnf -y module disable postgresql
+
 RUN dnf -y --nogpgcheck install postgresql13 \ 
                                 postgresql14 \
                                 postgresql15 \
                                 postgresql16 \
-    && dnf clean all
+ && dnf clean all
 
 RUN export PGSSLCIPHERS='TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:scram-sha-256'
 RUN export OPENSSL_FIPS=1
@@ -40,16 +69,15 @@ RUN export OPENSSL_FIPS=1
 RUN alternatives --install /usr/bin/psql psql /usr/pgsql-13/bin/psql 130 && \
     alternatives --install /usr/bin/psql psql /usr/pgsql-14/bin/psql 140 && \
     alternatives --install /usr/bin/psql psql /usr/pgsql-15/bin/psql 150 && \
-    alternatives --install /usr/bin/psql psql /usr/pgsql-16/bin/psql 160 
+    alternatives --install /usr/bin/psql psql /usr/pgsql-16/bin/psql 160 && \
+    alternatives --install /usr/bin/psql psql /usr/pgsql-16/bin/psql 170 
 
 RUN chmod -R 775 /var/lib/alternatives/ 
 RUN chmod -R 775 /etc/alternatives/ 
 
-RUN git clone --depth 1 https://github.com/brendangregg/perf-tools
 
-RUN pip3 install awscli redis
+RUN uv tool install awscli redis python3-PyMySQL python3-psycopg2
 
-ENV TERM=vt100
 
 ENV PS1="\[\e[31m\]\[\e[0m\]\ndebug-fedramp\[\e[0;32m\]\u\[\e[m\]@\[\e[0;33m\]\h\[\e[m\]:\[\e[0;34m\]\w\[\e[m\] \$ "
 

--- a/debug-container-fedramp/Dockerfile
+++ b/debug-container-fedramp/Dockerfile
@@ -1,5 +1,5 @@
 
-# Build an AppSRE FedRamp-centric container for debugging issues (see git clone below)
+# Build a FedRamp-centric (appsre-ft3) container for debugging issues 
 FROM quay.io/app-sre/ubi9-ubi-minimal@sha256:94b434a29a894129301f6ff52dbddb19422fc800a109170c634b056da8cd704f
 COPY --from=ghcr.io/astral-sh/uv:0.6.14@sha256:3362a526af7eca2fcd8604e6a07e873fb6e4286d8837cb753503558ce1213664 /uv /bin/uv
 
@@ -10,9 +10,10 @@ ENV \
     UV_NO_CACHE=true 
 
 
+# dnf required for greater package index and security advisories
 RUN microdnf install -y dnf 
 
-
+#force a refresh of dnf but only auto-apply security upgrades
 RUN dnf -y --refresh --security upgrade && \
     dnf -y install \
         alternatives \
@@ -51,7 +52,7 @@ RUN curl -LO ${OCP_URL} && \
 # anything normally installed via pip would go here (see: https://docs.astral.sh/uv/guides/integration/docker/#using-the-pip-interface)
 RUN uv pip install --system awscli redis psycopg PyMySQL
 
-   
+# add repos to install multiple versions of psql
 RUN dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-9.2-x86_64 \
  && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-9.2-x86_64 \
  && dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-9.2-x86_64 \
@@ -59,7 +60,7 @@ RUN dnf -y config-manager --add-repo https://download.postgresql.org/pub/repos/y
  && dnf update -y 
 
  
-
+# install multiple versions of psql
 RUN dnf -y --nogpgcheck install postgresql13 \ 
                                 postgresql14 \
                                 postgresql15 \
@@ -71,11 +72,13 @@ RUN export PGSSLCIPHERS='TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS
 RUN export OPENSSL_FIPS=1
 
 
+# FedRamp requires the ability to connect to multiple versions of Postgresql
+# the alternatives program allows a seamless switching between them
 RUN alternatives --install /usr/bin/psql psql /usr/pgsql-13/bin/psql 130 && \
     alternatives --install /usr/bin/psql psql /usr/pgsql-14/bin/psql 140 && \
     alternatives --install /usr/bin/psql psql /usr/pgsql-15/bin/psql 150 && \
     alternatives --install /usr/bin/psql psql /usr/pgsql-16/bin/psql 160 && \
-    alternatives --install /usr/bin/psql psql /usr/pgsql-16/bin/psql 170 
+    alternatives --install /usr/bin/psql psql /usr/pgsql-17/bin/psql 170 
 
 RUN chmod -R 775 /var/lib/alternatives/ 
 RUN chmod -R 775 /etc/alternatives/ 


### PR DESCRIPTION
context:
[APPSRE-11569](https://issues.redhat.com/browse/APPSRE-11569)

* Bump container image to ubi9
* install uv for python deps and make it first-class citizen
* install python-based tools using uv 
* install oc version needed for FR clusters
* remove unneeded packages/cruft