### PR TITLE
Fix: reduce Terraform version

### DIFF
--- a/dynatrace-ci/Dockerfile
+++ b/dynatrace-ci/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9-minimal@sha256:f172b3082a3d1bbe789a1057f038
 USER 0
 
 # Terraform versions and other related variables
-ENV TF_VERSION="1.6.6" \
+ENV TF_VERSION="1.6.0" \
     TF_PLUGIN_CACHE_DIR=/plugins/ \
     TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true
 


### PR DESCRIPTION
Reduce terraform version to comply with requirements from dynatace-config

Related to: [APPSRE-11027](https://issues.redhat.com/browse/APPSRE-11027)

Error on dynatrace-config pr-check:


```
18:31:52 Initializing modules...
18:31:52 - iam in ../modules/iam
18:31:52 ���
18:31:52 ��� Error: Unsupported Terraform Core version
18:31:52 ��� 
18:31:52 ���   on main.tf line 8, in terraform:
18:31:52 ���    8:   required_version = "~> 1.4, <1.6"
18:31:52 ��� 
18:31:52 ��� This configuration does not support Terraform version 1.6.6. To proceed,
18:31:52 ��� either choose another supported Terraform version or update this version
18:31:52 ��� constraint. Version constraints are normally set for good reason, so
18:31:52 ��� updating the constraint may lead to other errors or unexpected behavior.
18:31:52 ���
```