### PR TITLE
Return Terraform version to before Konflux migration

### DIFF
--- a/dynatrace-ci/Dockerfile
+++ b/dynatrace-ci/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9-minimal@sha256:f172b3082a3d1bbe789a1057f038
 USER 0
 
 # Terraform versions and other related variables
-ENV TF_VERSION="1.6.0" \
+ENV TF_VERSION="1.4.6" \
     TF_PLUGIN_CACHE_DIR=/plugins/ \
     TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true
 


### PR DESCRIPTION
Doing this will prevent the use of Konflux built image on `dynatrace-config` to no show new changes being added by a new version of Terraform

Previous version:
https://github.com/app-sre/container-images/pull/204/files#diff-f930b15c0f448661b8515a447940918982cb7911a53d946dfc8bb6768b009ee1L2