### PR TITLE
add LABEL to grafana-ubi & dynatrace-ci images

### DIFF
--- a/dynatrace-ci/Dockerfile
+++ b/dynatrace-ci/Dockerfile
@@ -28,6 +28,8 @@ RUN terraform providers mirror -platform=linux_amd64 /plugins
 # We want to be able to pull tf modules from internal repos
 FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master:0.5.0-1 AS prod
 
+LABEL konflux.additional-tags=0.5
+
 WORKDIR /terraform
 
 # We need git to fetch tf modules from git source

--- a/grafana-ubi/Dockerfile
+++ b/grafana-ubi/Dockerfile
@@ -11,6 +11,7 @@ RUN microdnf install -y tar gzip wget && mkdir /tmp/grafana-install && \
 FROM registry.access.redhat.com/ubi9-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290 AS base
 
 ARG GF_VERSION
+LABEL konflux.additional-tags=${GF_VERSION}
 
 COPY LICENSE /licenses/LICENSE
 


### PR DESCRIPTION
Adds `LABEL konflux.additional-tags` to grafana-ubi & dynatrace-ci images.

This is because after merging the pipelines for grafana-ubi, I see this error:

```
+++ [[ labels.konflux.additional-tags == labels.* ]]
+++ label=konflux.additional-tags
++++ jq -r --arg labelval konflux.additional-tags '.[$labelval] // ""'
+++ result=
+++ echo ''
++ replacement=
++ '[' -z '' ']'
++ echo Error: Substitution variable unknown or empty: labels.konflux.additional-tags
Error: Substitution variable unknown or empty: labels.konflux.additional-tags
++ exit 1
+ tags=
```

Adding this label to attempt to fix.