### PR TITLE
Add Tekton CI/CD pipeline configuration for go-httpbin service

### DIFF
--- a/.tekton/go-httpbin-master-pull-request.yaml
+++ b/.tekton/go-httpbin-master-pull-request.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/app-sre/container-images?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "10"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master" && files.all.exists(x, x.matches('go-httpbin/|.tekton/go-httpbin-master-pull-request.yaml|.tekton/go-httpbin-master-push.yaml'))
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: container-images-master
+    appstudio.openshift.io/component: go-httpbin-master
+    pipelines.appstudio.openshift.io/type: build
+  name: go-httpbin-master-on-pull-request
+  namespace: app-sre-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/app-sre-tenant/container-images-master/go-httpbin-master:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: go-httpbin/Dockerfile
+  - name: path-context
+    value: go-httpbin/
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/app-sre/shared-pipelines
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/multi-arch-build-pipeline.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-go-httpbin-master
+  workspaces:
+  - name: workspace
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {} 

--- a/.tekton/go-httpbin-master-push.yaml
+++ b/.tekton/go-httpbin-master-push.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/app-sre/container-images?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "25"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master" && files.all.exists(x, x.matches('go-httpbin/|.tekton/go-httpbin-master-pull-request.yaml|.tekton/go-httpbin-master-push.yaml'))
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: container-images-master
+    appstudio.openshift.io/component: go-httpbin-master
+    pipelines.appstudio.openshift.io/type: build
+  name: go-httpbin-master-on-push
+  namespace: app-sre-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/app-sre-tenant/container-images-master/go-httpbin-master:{{revision}}
+  - name: dockerfile
+    value: go-httpbin/Dockerfile
+  - name: path-context
+    value: go-httpbin/
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/app-sre/shared-pipelines
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/multi-arch-build-pipeline.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-go-httpbin-master
+  workspaces:
+  - name: workspace
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {} 


### PR DESCRIPTION
- Add go-httpbin-master-push.yaml: Builds production images on master branch pushes
- Add go-httpbin-master-pull-request.yaml: Builds test images for PR validation
- Pipelines trigger only on go-httpbin/ directory changes
- Uses multi-arch build pipeline with proper image tagging and retention
- Follows established patterns from existing service pipelines

APPSRE-11243