### PR TITLE
SDE-4648 - Add sloth binary to qr base

### DIFF
--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -18,7 +18,7 @@ ENV HELM_VERSION=3.11.1
 ENV GIT_SECRETS_VERSION=1.3.0
 ENV PROMETHEUS_VERSIONS="2.55.1 3.2.1"
 ENV ALERTMANAGER_VERSION=0.28.1
-ENV SLOTH_VERSION=0.12.0
+ARG SLOTH_VERSION=0.12.0
 
 
 RUN for version in ${TF_PROVIDER_AWS_VERSIONS}; do \
@@ -91,9 +91,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sfL https://github.com/prometheus/alertmanager/releases/download/v${ALERTMANAGER_VERSION}/alertmanager-${ALERTMANAGER_VERSION}.linux-amd64.tar.gz \
     | tar -zxf - -C /usr/local/bin --strip-components=1 alertmanager-${ALERTMANAGER_VERSION}.linux-amd64/amtool
 
-RUN curl -sfL https://github.com/slok/sloth/releases/download/v${SLOTH_VERSION}/sloth-linux-amd64 \
-    -o /usr/local/bin/sloth && \
-    chmod +x /usr/local/bin/sloth
+COPY --from=ghcr.io/slok/sloth:v${SLOTH_VERSION} /usr/local/bin/sloth /usr/local/bin/sloth
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:a50731d3397a4ee28583f1699842183d4d24fadcc565c4688487af9ee4e13a44 as prod
 

--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -95,7 +95,7 @@ COPY --from=ghcr.io/slok/sloth:v${SLOTH_VERSION} /usr/local/bin/sloth /usr/local
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:a50731d3397a4ee28583f1699842183d4d24fadcc565c4688487af9ee4e13a44 as prod
 
-LABEL konflux.additional-tags=1.0.0
+LABEL konflux.additional-tags=1.1.0
 
 ENV TF_PLUGIN_LOCAL_DIR=/usr/local/share/terraform/
 ENV TF_PLUGIN_CACHE_DIR=/.terraform.d/plugin-cache/

--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -18,6 +18,7 @@ ENV HELM_VERSION=3.11.1
 ENV GIT_SECRETS_VERSION=1.3.0
 ENV PROMETHEUS_VERSIONS="2.55.1 3.2.1"
 ENV ALERTMANAGER_VERSION=0.28.1
+ENV SLOTH_VERSION=0.12.0
 
 
 RUN for version in ${TF_PROVIDER_AWS_VERSIONS}; do \
@@ -90,6 +91,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sfL https://github.com/prometheus/alertmanager/releases/download/v${ALERTMANAGER_VERSION}/alertmanager-${ALERTMANAGER_VERSION}.linux-amd64.tar.gz \
     | tar -zxf - -C /usr/local/bin --strip-components=1 alertmanager-${ALERTMANAGER_VERSION}.linux-amd64/amtool
 
+RUN curl -sfL https://github.com/slok/sloth/releases/download/v${SLOTH_VERSION}/sloth-linux-amd64 \
+    -o /usr/local/bin/sloth && \
+    chmod +x /usr/local/bin/sloth
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:a50731d3397a4ee28583f1699842183d4d24fadcc565c4688487af9ee4e13a44 as prod
 
@@ -113,6 +117,7 @@ COPY --chown=0:0 --from=downloader \
     /usr/local/bin/git-secrets \
     /usr/local/bin/promtool* \
     /usr/local/bin/amtool \
+    /usr/local/bin/sloth \
     /usr/local/bin/
 
 COPY switch-promtool /usr/local/bin/


### PR DESCRIPTION
Add lastest release of https://sloth.dev/ to QR base image. 

Dependency for https://github.com/app-sre/qontract-reconcile/pull/5153