### PR TITLE
rds-enhanced-metrics-exporter: clean up Dockerfile

### DIFF
--- a/rds-enhanced-metrics-exporter/Dockerfile
+++ b/rds-enhanced-metrics-exporter/Dockerfile
@@ -6,7 +6,5 @@ RUN git clone --depth 1 https://github.com/percona/rds_exporter.git . && \
 RUN make release
 
 FROM registry.access.redhat.com/ubi8-minimal:8.2
-RUN microdnf update -y && rm -rf /var/cache/yum && microdnf install ca-certificates
-WORKDIR /
 COPY --from=builder /opt/app-root/src/rds_exporter/rds_exporter .
-ENTRYPOINT ["./rds_exporter", "--config.file=/rds-exporter-config/config.yml"]
+ENTRYPOINT ["/rds_exporter", "--config.file=/rds-exporter-config/config.yml"]


### PR DESCRIPTION
* Ensure we fetch a specific commit
* Use upstream's `make release` to build a binary which includes version info
* Remove usage of `microdnf update` so we run from a stable and predictable image
* Remove install of `ca-certificates` which is already included in the base image