### PR TITLE
Fix reloader VERSION ARG

### DIFF
--- a/reloader/Dockerfile
+++ b/reloader/Dockerfile
@@ -1,24 +1,24 @@
-ARG VERSION=v1.4.14
+ARG RELOADER_VERSION=v1.4.14
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8@sha256:77bfb0f283eaa3215909342c3dda940605eff5b9f72d6dc18fad1d154d172d55 as builder
-ARG VERSION
+ARG RELOADER_VERSION
 ENV GO111MODULE=on
 ENV GOTOOLCHAIN=go1.26.1
 WORKDIR /workspace
-RUN git clone --branch ${VERSION} --depth 1 \
+RUN git clone --branch ${RELOADER_VERSION} --depth 1 \
     https://github.com/stakater/Reloader.git .
 RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS:-linux} \
     GOARCH=${TARGETARCH} \
     GO111MODULE=on \
     go build -ldflags="-s -w \
-        -X github.com/stakater/Reloader/pkg/common.Version=${VERSION} \
+        -X github.com/stakater/Reloader/pkg/common.Version=${RELOADER_VERSION} \
         -X github.com/stakater/Reloader/pkg/common.Edition=oss" \
       -installsuffix 'static' -mod=mod -a -o manager ./
 
 FROM registry.access.redhat.com/ubi9-minimal@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
-ARG VERSION
-LABEL konflux.additional-tags=${VERSION}
+ARG RELOADER_VERSION
+LABEL konflux.additional-tags=${RELOADER_VERSION}
 WORKDIR /
 COPY --from=builder /workspace/manager /manager
 USER 65532:65532

--- a/reloader/README.md
+++ b/reloader/README.md
@@ -2,4 +2,4 @@
 
 Builds [Stakater Reloader](https://github.com/stakater/Reloader) from source. Reloader is a Kubernetes controller that watches for ConfigMap and Secret changes and triggers rolling upgrades on associated workloads.
 
-Pinned version is tracked in the `VERSION` ARG in `Dockerfile`.
+Pinned version is tracked in the `RELOADER_VERSION` ARG in `Dockerfile`.


### PR DESCRIPTION
The image `go-toolset` has a builtin `ENV VERSION=X.X.X`, making the pipeline [fail](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/app-sre-tenant/applications/container-images-master/pipelineruns/reloader-master-on-push-hsrc2/logs?task=build-container) when cloning the target repo. 