### PR TITLE
[APPSRE-13867-1] Upgrade grafana image to v11.6.11

### DIFF
--- a/grafana-ubi/Dockerfile
+++ b/grafana-ubi/Dockerfile
@@ -1,4 +1,4 @@
-ARG GF_VERSION="11.6.3"
+ARG GF_VERSION="11.6.11"
 
 FROM registry.access.redhat.com/ubi9-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290 AS downloader
 
@@ -25,7 +25,7 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 
 WORKDIR $GF_PATHS_HOME
 
-COPY --from=downloader --chown=1001:0 /tmp/grafana-install/grafana-v${GF_VERSION} /usr/share/grafana/
+COPY --from=downloader --chown=1001:0 /tmp/grafana-install/grafana-${GF_VERSION} /usr/share/grafana/
 
 RUN useradd -u 1001 -g 0 -r -d /usr/share/grafana -s /sbin/nologin grafana && \
     mkdir -p "$GF_PATHS_HOME/.aws" \


### PR DESCRIPTION
 ### Summary
  Upgrades Grafana container image from `v11.6.3` to `v11.6.11` to fix dashboard rendering timeouts.

  ### Problem
  Grafana v11.6.3 experiences rendering failures when attempting to render dashboards via the `/render` endpoint. The rendering process times out with 408 errors:

```
  logger=rendering renderer=http level=error msg="Remote rendering request failed" error="408 Request Timeout"
  logger=context method=GET path=/render/d/... status=500 duration=34.398s
```
  
  Root cause: Missing React JSX runtime dependencies. The browser requests `/react/jsx-runtime` and receives a 404, causing the frontend to hang indefinitely waiting for this critical dependency.

  ### Solution
  The issue was fixed in **v11.6.11** via commit `f5492da52d7` ([PR #117500](https://github.com/grafana/grafana/pull/117500)).

  **Fix:** Added `react/jsx-runtime` and `react/jsx-dev-runtime` to Grafana's shared plugin dependencies, allowing the frontend to properly load during rendering.
