### PR TITLE
feat(qontract-reconcile-base)!: upgrade to Python 3.14 on UBI10

### DIFF
--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi@sha256:dbc1e98d14a022542e45b5f22e0206d3f86b5bdf237b58ee7170c9ddd1b3a283 AS downloader
+FROM registry.access.redhat.com/ubi10/ubi@sha256:0ad01c46c6a173a5d9dd901afc695431448a8b0e02dc898d07836fe3c3977b92 AS downloader
 
 RUN dnf -y install unzip glibc-langpack-en
 
@@ -76,9 +76,9 @@ RUN curl -sfL https://github.com/prometheus/alertmanager/releases/download/v${AL
 
 COPY --from=ghcr.io/slok/sloth:v0.12.0@sha256:966590f31d9cb757034d20505579fc170ef562227faaf6e8f36609e64259f121 /usr/local/bin/sloth /usr/local/bin/sloth
 
-FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:30b4dc48a9f9661d9fc15795f2a144fdd1e8d2b59f4e5530eb51571f853270f3 AS prod
+FROM registry.access.redhat.com/ubi10/python-314-minimal@sha256:ee3ee7060695da0bc102a0dc523b76ae4332daf5909ef2f01a07d6feccd9bab2 AS prod
 
-LABEL konflux.additional-tags=1.5.2
+LABEL konflux.additional-tags=2.0.0
 
 ENV TF_PLUGIN_LOCAL_DIR=/usr/local/share/terraform/
 ENV TF_PLUGIN_CACHE_DIR=/.terraform.d/plugin-cache/


### PR DESCRIPTION
Switch the prod stage from ubi9/python-312-minimal to ubi10/python-314-minimal. Also update qontract-reconcile-builder to reference the new base image version 2.0.0.

Closes APPSRE-14363