### PR TITLE
revert(qontract-reconcile-base): downgrade to Python 3.12, add promtool 3.9.1

### DIFF
--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi@sha256:0ad01c46c6a173a5d9dd901afc695431448a8b0e02dc898d07836fe3c3977b92 AS downloader
+FROM registry.access.redhat.com/ubi9/ubi@sha256:dbc1e98d14a022542e45b5f22e0206d3f86b5bdf237b58ee7170c9ddd1b3a283 AS downloader
 
 RUN dnf -y install unzip glibc-langpack-en
 
@@ -12,7 +12,7 @@ ENV TF_PROVIDER_CLOUDINIT_VERSIONS="2.3.3"
 ENV TF_VERSION=1.6.6
 ENV HELM_VERSION=3.19.2
 ENV GIT_SECRETS_VERSION=1.3.0
-ENV PROMETHEUS_VERSIONS="2.55.1 3.9.1"
+ENV PROMETHEUS_VERSIONS="2.55.1 3.2.1"
 ENV ALERTMANAGER_VERSION=0.29.0
 
 
@@ -76,9 +76,9 @@ RUN curl -sfL https://github.com/prometheus/alertmanager/releases/download/v${AL
 
 COPY --from=ghcr.io/slok/sloth:v0.12.0@sha256:966590f31d9cb757034d20505579fc170ef562227faaf6e8f36609e64259f121 /usr/local/bin/sloth /usr/local/bin/sloth
 
-FROM registry.access.redhat.com/ubi10/python-314-minimal@sha256:ee3ee7060695da0bc102a0dc523b76ae4332daf5909ef2f01a07d6feccd9bab2 AS prod
+FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:30b4dc48a9f9661d9fc15795f2a144fdd1e8d2b59f4e5530eb51571f853270f3 AS prod
 
-LABEL konflux.additional-tags=2.1.0
+LABEL konflux.additional-tags=1.5.2
 
 ENV TF_PLUGIN_LOCAL_DIR=/usr/local/share/terraform/
 ENV TF_PLUGIN_CACHE_DIR=/.terraform.d/plugin-cache/

--- a/qontract-reconcile-base/Dockerfile
+++ b/qontract-reconcile-base/Dockerfile
@@ -12,7 +12,7 @@ ENV TF_PROVIDER_CLOUDINIT_VERSIONS="2.3.3"
 ENV TF_VERSION=1.6.6
 ENV HELM_VERSION=3.19.2
 ENV GIT_SECRETS_VERSION=1.3.0
-ENV PROMETHEUS_VERSIONS="2.55.1 3.2.1"
+ENV PROMETHEUS_VERSIONS="2.55.1 3.9.1"
 ENV ALERTMANAGER_VERSION=0.29.0
 
 
@@ -78,7 +78,7 @@ COPY --from=ghcr.io/slok/sloth:v0.12.0@sha256:966590f31d9cb757034d20505579fc170e
 
 FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:30b4dc48a9f9661d9fc15795f2a144fdd1e8d2b59f4e5530eb51571f853270f3 AS prod
 
-LABEL konflux.additional-tags=1.5.2
+LABEL konflux.additional-tags=1.6.0
 
 ENV TF_PLUGIN_LOCAL_DIR=/usr/local/share/terraform/
 ENV TF_PLUGIN_CACHE_DIR=/.terraform.d/plugin-cache/


### PR DESCRIPTION
## Summary

qontract-reconcile is not yet ready for Python 3.14, blocking base image bumps.

- **Commit 1**: Revert #304 — restore `ubi9/python-312-minimal` (Python 3.12), restore `1.x.x` version series
- **Commit 2**: Add promtool 3.9.1, drop unused 3.2.1, bump to `1.6.0`

Once qontract-reconcile completes its Python 3.14 migration, the 2.x.x series can be resumed.

## Test plan

- [ ] Konflux build produces image tagged `1.6.0-1`
- [ ] `promtool-3.9.1` present in built image
- [ ] `promtool-2.55.1` still present; `switch-promtool` works
- [ ] `promtool-3.2.1` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)