### PR TITLE
feat(qontract-reconcile-builder)!: bump base image to qontract-reconc…

### DIFF
--- a/qontract-reconcile-builder/Dockerfile
+++ b/qontract-reconcile-builder/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:2.0.0-1@sha256:88fe57608407bbe48e96750858909bdcca1d305a26bfc8077ae32a11a7973008
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:2.2.0-1@sha256:918bc54441031f48f5b9c0b8f99c3ff3fb260aec1390bf5bbd79dbf020730e39
 
-LABEL konflux.additional-tags=2.0.0
+LABEL konflux.additional-tags=2.2.0
 WORKDIR /work
 
 RUN mkdir ~/.gnupg && \


### PR DESCRIPTION
…ile-base 2.2.0

Updates the base image from 2.0.0 to 2.2.0, picking up Python 3.14 on UBI10.