### PR TITLE
chore(debug-container): bump version to trigger Konflux build for ECP validation

### DIFF
--- a/debug-container/Dockerfile
+++ b/debug-container/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.5@sha256:d07a5e080b8a9b3624d3c9cfbfada9a6baacd8e6d4065118f0e80c71ad518044
 
-LABEL konflux.additional-tags=0.4.1
+LABEL konflux.additional-tags=0.4.2
 
 # Enable required repositories
 RUN dnf module enable -y redis:7


### PR DESCRIPTION
## Summary

- Bumps `debug-container` from `0.4.1` to `0.4.2` (`konflux.additional-tags` label in Dockerfile)
- Purpose: trigger a Konflux pipeline run to verify that the container-images `ReleasePlanAdmission` works correctly with the new `app-interface-app-sre-trusted-tasks-prod` EnterpriseContractPolicy (deployed via [konflux-release-data MR !20254](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/20254))

## Why not an empty commit?

This is a multi-component repo where Tekton pipelines use CEL expressions to trigger builds based on which directory has file changes. An empty commit would not trigger any pipeline.

## Context

As part of [APPSRE-14854](https://issues.redhat.com/browse/APPSRE-14854), we migrated the container-images RPA from the shared `app-interface-standard` ECP to a new `app-interface-app-sre-trusted-tasks-prod` ECP that enables `trusted_task_rules_enabled: true` for rule-based trusted task validation.

This PR triggers a new build so that Konflux runs the full release pipeline (including Enterprise Contract validation) against the new policy, confirming:
1. The new ECP is correctly applied
2. Trusted task validation passes with the shared pipeline's custom tasks (goss container-structure-test)
3. No regressions in the release flow

## Test plan

- [ ] Konflux build pipeline completes successfully
- [ ] Enterprise Contract validation passes with the new ECP
- [ ] Release pipeline succeeds end-to-end
- [ ] Verify in Konflux UI that container-images release uses `app-interface-app-sre-trusted-tasks-prod` policy

JIRA: APPSRE-14854