### PR TITLE
fix(rds-enhanced-metrics-exporter): pin full commit SHA for shallow clone

### DIFF
--- a/rds-enhanced-metrics-exporter/Dockerfile
+++ b/rds-enhanced-metrics-exporter/Dockerfile
@@ -1,7 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset@sha256:14c369670cf3473d8e9b93e42d120c01b79a6f13884c396a1c89b7ca46f859b7 as builder
-ENV COMMIT=8de8628
+ENV COMMIT=8de8628580736b9ac74ad084b1844a75fbef8933
 WORKDIR rds_exporter
-RUN git clone --depth 1 https://github.com/percona/rds_exporter.git . && \
+RUN git init && \
+    git remote add origin https://github.com/percona/rds_exporter.git && \
+    git fetch --depth 1 origin $COMMIT && \
     git checkout $COMMIT
 RUN make release
 


### PR DESCRIPTION
## Summary
- Build was failing: `git clone --depth 1 https://github.com/percona/rds_exporter.git . && git checkout $COMMIT` errors with `pathspec '8de8628' did not match any file(s) known to git`
- Root cause: `--depth 1` only fetches the upstream default branch tip. `8de8628` was that tip when the Dockerfile was written, but upstream's `main` has since moved 9 commits ahead, so the shallow clone no longer contains it. PR #216 (an unrelated digest bump) just invalidated the build cache and surfaced the latent bug.
- Fix: shallow-fetch the exact commit by full SHA (`git fetch --depth 1 origin $COMMIT`) instead of shallow-cloning the branch tip. This is independent of wherever upstream's default branch currently points. Note this requires the *full* 40-char SHA — GitHub's `uploadpack.allowReachableSHA1InWant` only resolves fetch-by-SHA for full hashes, not abbreviated ones — so `COMMIT` was updated from `8de8628` to `8de8628580736b9ac74ad084b1844a75fbef8933`.

Verified against the real `percona/rds_exporter` repo that this fetch/checkout sequence succeeds and resolves to the same commit.

Reported in https://redhat-internal.slack.com/archives/C098G63A9JQ/p1785752310537589 (rds-enhanced-metrics-exporter build failing in #216).

## Test plan
- [ ] Konflux build for `rds-enhanced-metrics-exporter` succeeds on this branch
- [ ] Once merged, rebase/re-run #216 to confirm its build now passes too